### PR TITLE
Add google-chrome to app_id

### DIFF
--- a/icons-wl
+++ b/icons-wl
@@ -26,6 +26,7 @@ for_window [app_id=^gimp-] title_format "­<span size='150%' font-weight='normal
 for_window [app_id=^gnome-boxes$] title_format "­<span size='120%' font-weight='normal'></span> %title"
 for_window [app_id=^gnome-mines$] title_format "­<span size='120%' font-weight='normal'>󰈿</span> %title"
 for_window [app_id=^gnome-tetravex$] title_format "­<span size='120%' font-weight='normal'>󰐱</span> %title"
+for_window [app_id=^google-chrome$] title_format "­<span size='110%' font-weight='normal'></span> %title"
 for_window [app_id=^gtk3-|^org.gtk.] title_format "­<span size='120%' font-weight='normal'></span> %title"
 for_window [app_id=^heroic$] title_format "­<span size='133%' font-weight='normal'>󱢾</span> %title"
 for_window [app_id=^info.mumble.Mumble$] title_format "­<span size='120%' font-weight='normal'>󰋎</span> %title"


### PR DESCRIPTION
It appears that the Google Chrome update has made Wayland the default. I apologize if I am mistaken.
In my environment, Chromium remains as class, so I am uncertain how it will be expressed when it becomes app_id.